### PR TITLE
Allow to configure extra apache settings with HTTPD_EXTRA_CONF

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Vhost.
    * Laravel:  `/app/public`
    * Neos:  `/app/Web`
 
+* `HTTPD_EXTRA_CONF`: multiline string of extra configuration to put into httpd.conf. For example
+  can be used to load extra Apache modules, i.e.
+  ```
+  HTTPD_EXTRA_CONF="
+  LoadModule deflate_module modules/mod_deflate.so
+  "
+  ```
+
 * `SSL_CRT`, `SSL_KEY`: Add your SSL certificate and private key here (the PEM strings,
   not the filenames) to enable Apache with SSL support. It will automatically listen to port "8443"
 

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -29,6 +29,13 @@ else
   rm -f /usr/local/apache2/conf/extra/httpd-vhost-ssl.conf
 fi
 
+# Add extra configuration from HTTPD_EXTRA_CONF variable
+if [ ! -z "$HTTPD_EXTRA_CONF" ]; then
+  echo $HTTPD_EXTRA_CONF > /usr/local/apache2/conf/extra/custom.conf
+else
+  echo> /usr/local/apache2/conf/extra/custom.conf
+fi
+
 # prepare vhost conf for HTTP
 VHOST="*:${WEB_PORTS_HTTP// / *:}"
 sed -e "s/###VHOST###/$VHOST/g;" /opt/docker-phpapp-web/httpd-vhost.conf > /usr/local/apache2/conf/extra/httpd-vhost.conf

--- a/files/httpd.conf
+++ b/files/httpd.conf
@@ -195,3 +195,6 @@ SSLRandomSeed connect builtin
 </IfModule>
 
 ServerName localhost
+
+# Load custom httpd.conf settings (from docker .env HTTPD_EXTRA_CONF)
+Include conf/extra/custom*.conf


### PR DESCRIPTION
New setting configurable via ENV-variable: `HTTPD_EXTRA_CONF`: multiline string of extra configuration to put into httpd.conf. For example can be used to load extra Apache modules, i.e.
```
HTTPD_EXTRA_CONF="
LoadModule deflate_module modules/mod_deflate.so
"
``` 