### PR TITLE
Add healthcheck to web container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM httpd:2.4
 
 # We will need openssl tool for the entrypoint
-RUN apt-get -qq update && apt-get -q install -y openssl && rm -rf /var/lib/apt/lists/*
+RUN apt-get -qq update && apt-get -q install -y openssl netcat && rm -rf /var/lib/apt/lists/*
 
 # Prepare our apache configuration
 RUN rm /usr/local/apache2/conf/extra/httpd-vhosts.conf /usr/local/apache2/conf/original/extra/httpd-ssl.conf
@@ -15,6 +15,9 @@ RUN chmod 644 /usr/local/apache2/conf/httpd.conf /usr/local/apache2/conf/extra/h
 # We need an alternative entrypoint to do some stuff upon starting the container
 COPY files/entrypoint.sh /
 RUN chmod 755 /entrypoint.sh
+
+# Configure healthcheck - use "nc" to see if port 80 is open, because curl might still get errors (403, etc)
+HEALTHCHECK --interval=5s --timeout=3s CMD nc -z -v localhost 80 || exit 1
 
 # Also expose SSL port
 EXPOSE 80 443


### PR DESCRIPTION
Uses netcat instead of curl because the webserver might have started but the content is not yet in place or some other PHP error being thrown (500, 443, etc), which is not the fault of the web container.