### PR TITLE
Avoid PHP_PORT variable name as it conflicts with "links: php:php"

### DIFF
--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -3,14 +3,14 @@ set -e
 
 # Export these so that apache can use them in the configuration files directly
 export APP_WEBROOT=${APP_WEBROOT:-/app/html}
-export PHP_HOSTNAME=${PHP_HOSTNAME:-php}
-export PHP_PORT=${PHP_PORT:-9000}
+export PHPFPM_HOSTNAME=${PHPFPM_HOSTNAME:-php}
+export PHPFPM_PORT=${PHPFPM_PORT:-9000}
 
 # List of ports to listen to, space separated list
 WEB_PORTS_HTTP=${WEB_PORTS_HTTP:-80}
 
 echo "* DocumentRoot: $APP_WEBROOT"
-echo "* PHP-FPM: $PHP_HOSTNAME:$PHP_PORT"
+echo "* PHP-FPM: $PHPFPM_HOSTNAME:$PHPFPM_PORT"
 
 # If env variables SSL_KEY and SSL_CRT are set, configure apache for SSL access
 if [ ! -z "$SSL_KEY" ] && [ ! -z "$SSL_CRT" ]; then

--- a/files/httpd-vhost-ssl.conf
+++ b/files/httpd-vhost-ssl.conf
@@ -10,7 +10,7 @@ SSLProxyProtocol all -SSLv3
 
     # Handle PHP with PHP-FPM
     <FilesMatch "\.php$">
-        SetHandler "proxy:fcgi://${PHP_HOSTNAME}:${PHP_PORT}"
+        SetHandler "proxy:fcgi://${PHPFPM_HOSTNAME}:${PHPFPM_PORT}"
     </FilesMatch>
 
     # If the php file doesn't exist, disable the proxy handler.

--- a/files/httpd-vhost.conf
+++ b/files/httpd-vhost.conf
@@ -4,7 +4,7 @@
 
     # Handle PHP with PHP-FPM
     <FilesMatch "\.php$">
-        SetHandler "proxy:fcgi://${PHP_HOSTNAME}:${PHP_PORT}"
+        SetHandler "proxy:fcgi://${PHPFPM_HOSTNAME}:${PHPFPM_PORT}"
     </FilesMatch>
 
     # If the php file doesn't exist, disable the proxy handler.


### PR DESCRIPTION
In an ECS template we might want to use `links: php:php` which generate an environment variable called `PHP_PORT` (which contain a string like "tcp://172.17.0.4:9000") and this conflicts with our own "internal" variable.

See https://docs.docker.com/network/links/#environment-variables

So we use another name that is non-conflicting.