### PR TITLE
Use netcat-traditional, we are now using Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM httpd:2.4
 
 # We will need openssl tool for the entrypoint
-RUN apt-get -qq update && apt-get -q install -y openssl netcat && rm -rf /var/lib/apt/lists/*
+RUN apt-get -qq update && apt-get -q install -y openssl netcat-traditional && rm -rf /var/lib/apt/lists/*
 
 # Prepare our apache configuration
 RUN rm /usr/local/apache2/conf/extra/httpd-vhosts.conf /usr/local/apache2/conf/original/extra/httpd-ssl.conf


### PR DESCRIPTION
Upstream httpd image now uses Debian Bookworm, which does not have a `netcat` package anymore:

```
Package netcat is a virtual package provided by:
  netcat-openbsd 1.219-1
  netcat-traditional 1.10-47

E: Package 'netcat' has no installation candidate
```
